### PR TITLE
Add comprehensive unit tests for service layer

### DIFF
--- a/src/services/consultorio/consultorio.service.spec.ts
+++ b/src/services/consultorio/consultorio.service.spec.ts
@@ -1,18 +1,76 @@
-import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException } from '@nestjs/common';
 import { ConsultorioService } from './consultorio.service';
+import { createMockRepository } from '../../../test/utils/mock-repository';
+import { ConsultorioEntity } from '../../entities/consultorio.entity';
 
 describe('ConsultorioService', () => {
   let service: ConsultorioService;
+  const repository = createMockRepository<ConsultorioEntity>();
 
-  beforeEach(async () => {
-    const module: TestingModule = await Test.createTestingModule({
-      providers: [ConsultorioService],
-    }).compile();
-
-    service = module.get<ConsultorioService>(ConsultorioService);
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new ConsultorioService(repository as any);
   });
 
-  it('should be defined', () => {
-    expect(service).toBeDefined();
+  it('should create a consultorio', async () => {
+    const dto = { numero: '101', descripcion: 'Pediatría' } as any;
+    const entity = { id: 1, ...dto } as ConsultorioEntity;
+    repository.create!.mockReturnValue(entity);
+    repository.save!.mockResolvedValue(entity);
+
+    const result = await service.create(dto);
+
+    expect(repository.create).toHaveBeenCalledWith(dto);
+    expect(repository.save).toHaveBeenCalledWith(entity);
+    expect(result).toBe(entity);
+  });
+
+  it('should edit a consultorio', async () => {
+    const entity = { id: 1, numero: '101' } as ConsultorioEntity;
+    const dto = { numero: '102' } as any;
+    repository.findOneBy!.mockResolvedValue(entity);
+    repository.save!.mockResolvedValue({ ...entity, ...dto });
+
+    const result = await service.edit(entity.id, dto);
+
+    expect(repository.merge).toHaveBeenCalledWith(entity, dto);
+    expect(repository.save).toHaveBeenCalledWith(entity);
+    expect(result).toEqual({ ...entity, ...dto });
+  });
+
+  it('should delete a consultorio', async () => {
+    const entity = { id: 1, numero: '101' } as ConsultorioEntity;
+    repository.findOneBy!.mockResolvedValue(entity);
+
+    const result = await service.delete(entity.id);
+
+    expect(repository.remove).toHaveBeenCalledWith(entity);
+    expect(result.message).toContain(entity.numero);
+  });
+
+  it('should return all consultorios', async () => {
+    const entities = [{ id: 1 } as ConsultorioEntity];
+    repository.find!.mockResolvedValue(entities);
+
+    const result = await service.findAll();
+
+    expect(result).toBe(entities);
+    expect(repository.find).toHaveBeenCalled();
+  });
+
+  it('should find a consultorio by id', async () => {
+    const entity = { id: 1 } as ConsultorioEntity;
+    repository.findOneBy!.mockResolvedValue(entity);
+
+    const result = await service.findOne(1);
+
+    expect(result).toBe(entity);
+    expect(repository.findOneBy).toHaveBeenCalledWith({ id: 1 });
+  });
+
+  it('should throw when consultorio not found', async () => {
+    repository.findOneBy!.mockResolvedValue(null);
+
+    await expect(service.findOne(99)).rejects.toThrow(NotFoundException);
   });
 });

--- a/src/services/empleado/empleado.service.spec.ts
+++ b/src/services/empleado/empleado.service.spec.ts
@@ -1,18 +1,227 @@
-import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { createMockRepository } from '../../../test/utils/mock-repository';
 import { EmpleadoService } from './empleado.service';
+import { EmpleadoEntity } from '../../entities/empleado.entity';
+import { TipoEmpleadoService } from '../tipo-empleado/tipo-empleado.service';
+import { UsersService } from '../users/users.service';
+import { EspecialidadService } from '../especialidad/especialidad.service';
+import { PersonaService } from '../persona/persona.service';
+import { ConsultorioService } from '../consultorio/consultorio.service';
+import { ProcedimientoService } from '../procedimiento/procedimiento.service';
+
+const createDataSource = () => ({
+  transaction: jest.fn(),
+});
 
 describe('EmpleadoService', () => {
+  const repository = createMockRepository<EmpleadoEntity>();
+  const tipoEmpleadoService = { findOne: jest.fn() } as unknown as TipoEmpleadoService;
+  const userService = { register: jest.fn() } as unknown as UsersService;
+  const especialidadService = { findOne: jest.fn() } as unknown as EspecialidadService;
+  const personaService = { create: jest.fn() } as unknown as PersonaService;
+  const consultorioService = { findOne: jest.fn() } as unknown as ConsultorioService;
+  const procedimientoService = { findOne: jest.fn() } as unknown as ProcedimientoService;
+  const dataSource = createDataSource() as any;
   let service: EmpleadoService;
 
-  beforeEach(async () => {
-    const module: TestingModule = await Test.createTestingModule({
-      providers: [EmpleadoService],
-    }).compile();
-
-    service = module.get<EmpleadoService>(EmpleadoService);
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new EmpleadoService(
+      tipoEmpleadoService,
+      userService,
+      especialidadService,
+      personaService,
+      consultorioService,
+      procedimientoService,
+      repository as any,
+      dataSource,
+    );
   });
 
-  it('should be defined', () => {
-    expect(service).toBeDefined();
+  it('creates an employee inside a transaction', async () => {
+    const dto = {
+      idTipoEmpleado: 1,
+      idEspecialidad: 2,
+      idConsultorio: 3,
+      email: 'user@example.com',
+      password: 'secret',
+    } as any;
+    const tipoEmpleado = { id: 1, nombre: 'Doctor' } as any;
+    const especialidad = { id: 2 } as any;
+    const consultorio = { id: 3 } as any;
+    const persona = { id: 4 } as any;
+    const user = { id: 5 } as any;
+    const empleado = { id: 6 } as EmpleadoEntity;
+    const managerRepository = { save: jest.fn().mockResolvedValue(empleado) };
+    dataSource.transaction.mockImplementation(async (cb: any) => cb({ getRepository: () => managerRepository }));
+    tipoEmpleadoService.findOne = jest.fn().mockResolvedValue(tipoEmpleado);
+    especialidadService.findOne = jest.fn().mockResolvedValue(especialidad);
+    consultorioService.findOne = jest.fn().mockResolvedValue(consultorio);
+    personaService.create = jest.fn().mockResolvedValue(persona);
+    userService.register = jest.fn().mockResolvedValue(user);
+    repository.create!.mockReturnValue(empleado);
+
+    const result = await service.create(dto);
+
+    expect(tipoEmpleadoService.findOne).toHaveBeenCalledWith(dto.idTipoEmpleado);
+    expect(especialidadService.findOne).toHaveBeenCalledWith(dto.idEspecialidad);
+    expect(consultorioService.findOne).toHaveBeenCalledWith(dto.idConsultorio);
+    expect(personaService.create).toHaveBeenCalled();
+    expect(userService.register).toHaveBeenCalledWith(dto.email, dto.password, expect.anything());
+    expect(repository.create).toHaveBeenCalledWith({
+      tipoEmpleado,
+      especialidad,
+      consultorio,
+      persona,
+      user,
+    });
+    expect(managerRepository.save).toHaveBeenCalledWith(empleado);
+    expect(result).toBe(empleado);
+  });
+
+  it('finds employee by id', async () => {
+    const empleado = { id: 1 } as EmpleadoEntity;
+    repository.findOneBy!.mockResolvedValue(empleado);
+
+    const result = await service.findById(1);
+
+    expect(result).toBe(empleado);
+  });
+
+  it('throws when employee by id not found', async () => {
+    repository.findOneBy!.mockResolvedValue(null);
+
+    await expect(service.findById(1)).rejects.toThrow(NotFoundException);
+  });
+
+  it('finds all employees with relations', async () => {
+    const employees = [{ id: 1 } as EmpleadoEntity];
+    repository.find!.mockResolvedValue(employees);
+
+    const result = await service.findAll();
+
+    expect(repository.find).toHaveBeenCalledWith({
+      relations: ['tipoEmpleado', 'especialidad', 'persona', 'user'],
+    });
+    expect(result).toBe(employees);
+  });
+
+  it('finds one employee by id with relations', async () => {
+    const empleado = { id: 1 } as EmpleadoEntity;
+    repository.findOne!.mockResolvedValue(empleado);
+
+    const result = await service.findOne(1);
+
+    expect(repository.findOne).toHaveBeenCalledWith({
+      where: { id: 1 },
+      relations: ['tipoEmpleado', 'especialidad', 'persona', 'user'],
+    });
+    expect(result).toBe(empleado);
+  });
+
+  it('throws when employee not found by id', async () => {
+    repository.findOne!.mockResolvedValue(null);
+
+    await expect(service.findOne(1)).rejects.toThrow('El id: 1 no corresponde a ningun empleado');
+  });
+
+  it('finds employee by user', async () => {
+    const empleado = { id: 1 } as EmpleadoEntity;
+    const user = { email: 'user@example.com' } as any;
+    repository.findOne!.mockResolvedValue(empleado);
+
+    const result = await service.findByUser(user);
+
+    expect(repository.findOne).toHaveBeenCalledWith({
+      where: { user },
+      relations: ['tipoEmpleado', 'especialidad', 'persona'],
+    });
+    expect(result).toBe(empleado);
+  });
+
+  it('throws when employee not found by user', async () => {
+    repository.findOne!.mockResolvedValue(null);
+
+    await expect(service.findByUser({ email: 'missing@example.com' } as any)).rejects.toThrow('El usuario: missing@example.com no corresponde a ningun empleado');
+  });
+
+  it('finds all doctors', async () => {
+    repository.find!.mockResolvedValue([]);
+
+    await service.findAllDoctors();
+
+    expect(repository.find).toHaveBeenCalledWith({
+      where: { tipoEmpleado: { nombre: 'Doctor' } },
+      relations: ['tipoEmpleado', 'especialidad', 'persona'],
+    });
+  });
+
+  it('changes employee type', async () => {
+    const empleado = { id: 1, tipoEmpleado: { id: 1 } } as EmpleadoEntity;
+    repository.findOne!.mockResolvedValue(empleado);
+    tipoEmpleadoService.findOne = jest.fn().mockResolvedValue({ id: 2 });
+    repository.save!.mockResolvedValue({ ...empleado, tipoEmpleado: { id: 2 } });
+
+    const result = await service.changeTipoEmpleado(1, 2);
+
+    expect(tipoEmpleadoService.findOne).toHaveBeenCalledWith(2);
+    expect(repository.save).toHaveBeenCalledWith(empleado);
+    expect(result.tipoEmpleado).toEqual({ id: 2 });
+  });
+
+  it('assigns especialidad to doctor', async () => {
+    const especialidad = { id: 2 } as any;
+    const empleado = { id: 1, tipoEmpleado: { nombre: 'Doctor' } } as EmpleadoEntity;
+    repository.findOne!.mockResolvedValue(empleado);
+    especialidadService.findOne = jest.fn().mockResolvedValue(especialidad);
+    repository.save!.mockResolvedValue({ ...empleado, especialidad });
+
+    const result = await service.assignEspecialidad(1, 2);
+
+    expect(especialidadService.findOne).toHaveBeenCalledWith(2);
+    expect(repository.save).toHaveBeenCalledWith(empleado);
+    expect(result.especialidad).toBe(especialidad);
+  });
+
+  it('throws when assigning especialidad to non doctor', async () => {
+    const empleado = { id: 1, tipoEmpleado: { nombre: 'Recepcionista' } } as EmpleadoEntity;
+    repository.findOne!.mockResolvedValue(empleado);
+
+    await expect(service.assignEspecialidad(1, 2)).rejects.toThrow(BadRequestException);
+  });
+
+  it('assigns procedimientos', async () => {
+    const procedimientos = [{ id: 1 } as any, { id: 2 } as any];
+    const empleado = { id: 1, procedimientos: [] } as EmpleadoEntity;
+    repository.findOne!.mockResolvedValue(empleado);
+    procedimientoService.findOne = jest.fn().mockResolvedValueOnce(procedimientos[0]).mockResolvedValueOnce(procedimientos[1]);
+    repository.save!.mockResolvedValue({ ...empleado, procedimientos });
+
+    const result = await service.assignProcedimiento(1, { procedimientosIds: [1, 2] } as any);
+
+    expect(procedimientoService.findOne).toHaveBeenCalledTimes(2);
+    expect(repository.save).toHaveBeenCalledWith(empleado);
+    expect(result.procedimientos).toEqual(procedimientos);
+  });
+
+  it('assigns consultorio to doctor', async () => {
+    const consultorio = { id: 1 } as any;
+    const empleado = { id: 1, tipoEmpleado: { nombre: 'Doctor' } } as EmpleadoEntity;
+    repository.findOne!.mockResolvedValue(empleado);
+    consultorioService.findOne = jest.fn().mockResolvedValue(consultorio);
+    repository.save!.mockResolvedValue({ ...empleado, consultorio });
+
+    const result = await service.assignConsultorio(1, 1);
+
+    expect(consultorioService.findOne).toHaveBeenCalledWith(1);
+    expect(repository.save).toHaveBeenCalledWith(empleado);
+    expect(result.consultorio).toBe(consultorio);
+  });
+
+  it('throws when assigning consultorio to non doctor', async () => {
+    const empleado = { id: 1, tipoEmpleado: { nombre: 'Recepcionista' } } as EmpleadoEntity;
+    repository.findOne!.mockResolvedValue(empleado);
+
+    await expect(service.assignConsultorio(1, 1)).rejects.toThrow(BadRequestException);
   });
 });

--- a/src/services/especialidad/especialidad.service.spec.ts
+++ b/src/services/especialidad/especialidad.service.spec.ts
@@ -1,43 +1,74 @@
 import { NotFoundException } from '@nestjs/common';
+import { createMockRepository } from '../../../test/utils/mock-repository';
 import { EspecialidadService } from './especialidad.service';
 import { EspecialidadEntity } from '../../entities/especialidad.entity';
 
 describe('EspecialidadService', () => {
+  const repository = createMockRepository<EspecialidadEntity>();
   let service: EspecialidadService;
-  let repo: any;
 
   beforeEach(() => {
-    repo = {
-      find: jest.fn(),
-      findOneBy: jest.fn(),
-    };
-    service = new EspecialidadService(repo as any);
+    jest.clearAllMocks();
+    service = new EspecialidadService(repository as any);
   });
 
-  it('findAll should return all especialidades', async () => {
-    const especialidades = [
-      { id: 1, nombre: 'Cardiología' },
-      { id: 2, nombre: 'Pediatría' },
-    ] as EspecialidadEntity[];
-    repo.find.mockResolvedValue(especialidades);
+  it('creates a specialty', async () => {
+    const dto = { nombre: 'Cardiología' } as any;
+    const entity = { id: 1, ...dto } as EspecialidadEntity;
+    repository.create!.mockReturnValue(entity);
+    repository.save!.mockResolvedValue(entity);
+
+    const result = await service.create(dto);
+
+    expect(repository.create).toHaveBeenCalledWith(dto);
+    expect(repository.save).toHaveBeenCalledWith(entity);
+    expect(result).toBe(entity);
+  });
+
+  it('updates a specialty', async () => {
+    const entity = { id: 1, nombre: 'Cardiología' } as EspecialidadEntity;
+    const dto = { nombre: 'Pediatría' } as any;
+    repository.findOneBy!.mockResolvedValue(entity);
+    repository.save!.mockResolvedValue({ ...entity, ...dto });
+
+    const result = await service.edit(entity.id, dto);
+
+    expect(repository.merge).toHaveBeenCalledWith(entity, dto);
+    expect(repository.save).toHaveBeenCalledWith(entity);
+    expect(result).toEqual({ ...entity, ...dto });
+  });
+
+  it('deletes a specialty', async () => {
+    const entity = { id: 1, nombre: 'Cardiología' } as EspecialidadEntity;
+    repository.findOneBy!.mockResolvedValue(entity);
+
+    const result = await service.delete(entity.id);
+
+    expect(repository.remove).toHaveBeenCalledWith(entity);
+    expect(result.message).toContain(entity.nombre);
+  });
+
+  it('returns all specialties', async () => {
+    const entities = [{ id: 1 } as EspecialidadEntity];
+    repository.find!.mockResolvedValue(entities);
 
     const result = await service.findAll();
-    expect(result).toEqual(especialidades);
-    expect(repo.find).toHaveBeenCalled();
+
+    expect(result).toBe(entities);
   });
 
-  it('findOne should return especialidad if found', async () => {
-    const especialidad = { id: 1, nombre: 'Cardiología' } as EspecialidadEntity;
-    repo.findOneBy.mockResolvedValue(especialidad);
+  it('finds a specialty by id', async () => {
+    const entity = { id: 1 } as EspecialidadEntity;
+    repository.findOneBy!.mockResolvedValue(entity);
 
     const result = await service.findOne(1);
-    expect(result).toEqual(especialidad);
-    expect(repo.findOneBy).toHaveBeenCalledWith({ id: 1 });
+
+    expect(result).toBe(entity);
   });
 
-  it('findOne should throw NotFoundException if not found', async () => {
-    repo.findOneBy.mockResolvedValue(undefined);
+  it('throws when specialty not found', async () => {
+    repository.findOneBy!.mockResolvedValue(null);
 
-    await expect(service.findOne(99)).rejects.toBeInstanceOf(NotFoundException);
+    await expect(service.findOne(1)).rejects.toThrow(NotFoundException);
   });
 });

--- a/src/services/estado-turno/estado-turno.service.spec.ts
+++ b/src/services/estado-turno/estado-turno.service.spec.ts
@@ -1,18 +1,73 @@
-import { Test, TestingModule } from '@nestjs/testing';
+import { createMockRepository } from '../../../test/utils/mock-repository';
 import { EstadoTurnoService } from './estado-turno.service';
+import { EstadoTurnoEntity } from '../../entities/estadoTurno.entity';
 
 describe('EstadoTurnoService', () => {
+  const repository = createMockRepository<EstadoTurnoEntity>();
   let service: EstadoTurnoService;
 
-  beforeEach(async () => {
-    const module: TestingModule = await Test.createTestingModule({
-      providers: [EstadoTurnoService],
-    }).compile();
-
-    service = module.get<EstadoTurnoService>(EstadoTurnoService);
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new EstadoTurnoService(repository as any);
   });
 
-  it('should be defined', () => {
-    expect(service).toBeDefined();
+  it('creates a estado turno', async () => {
+    const dto = { nombre: 'Pendiente' } as any;
+    const entity = { id: 1, ...dto } as EstadoTurnoEntity;
+    repository.create!.mockReturnValue(entity);
+    repository.save!.mockResolvedValue(entity);
+
+    const result = await service.create(dto);
+
+    expect(repository.create).toHaveBeenCalledWith(dto);
+    expect(repository.save).toHaveBeenCalledWith(entity);
+    expect(result).toBe(entity);
+  });
+
+  it('edits a estado turno', async () => {
+    const entity = { id: 1, nombre: 'Pendiente' } as EstadoTurnoEntity;
+    const dto = { nombre: 'Confirmado' } as any;
+    repository.findOneBy!.mockResolvedValue(entity);
+    repository.save!.mockResolvedValue({ ...entity, ...dto });
+
+    const result = await service.edit(entity.id, dto);
+
+    expect(repository.merge).toHaveBeenCalledWith(entity, dto);
+    expect(repository.save).toHaveBeenCalledWith(entity);
+    expect(result).toEqual({ ...entity, ...dto });
+  });
+
+  it('deletes a estado turno', async () => {
+    const entity = { id: 1, nombre: 'Pendiente' } as EstadoTurnoEntity;
+    repository.findOneBy!.mockResolvedValue(entity);
+
+    const result = await service.delete(entity.id);
+
+    expect(repository.remove).toHaveBeenCalledWith(entity);
+    expect(result.message).toContain(entity.nombre);
+  });
+
+  it('finds all estados', async () => {
+    const entities = [{ id: 1 } as EstadoTurnoEntity];
+    repository.find!.mockResolvedValue(entities);
+
+    const result = await service.findAll();
+
+    expect(result).toBe(entities);
+  });
+
+  it('finds by id', async () => {
+    const entity = { id: 1 } as EstadoTurnoEntity;
+    repository.findOneBy!.mockResolvedValue(entity);
+
+    const result = await service.findOne(1);
+
+    expect(result).toBe(entity);
+  });
+
+  it('throws when not found', async () => {
+    repository.findOneBy!.mockResolvedValue(null);
+
+    await expect(service.findOne(1)).rejects.toThrow('No existe el estado de turno con el id: 1');
   });
 });

--- a/src/services/grupo-sanguineo/grupo-sanguineo.service.spec.ts
+++ b/src/services/grupo-sanguineo/grupo-sanguineo.service.spec.ts
@@ -1,18 +1,61 @@
-import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException } from '@nestjs/common';
+import { createMockRepository } from '../../../test/utils/mock-repository';
 import { GrupoSanguineoService } from './grupo-sanguineo.service';
+import { GrupoSanguineoEntity } from '../../entities/grupoSanguineo.entity';
 
 describe('GrupoSanguineoService', () => {
+  const repository = createMockRepository<GrupoSanguineoEntity>();
   let service: GrupoSanguineoService;
 
-  beforeEach(async () => {
-    const module: TestingModule = await Test.createTestingModule({
-      providers: [GrupoSanguineoService],
-    }).compile();
-
-    service = module.get<GrupoSanguineoService>(GrupoSanguineoService);
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new GrupoSanguineoService(repository as any);
   });
 
-  it('should be defined', () => {
-    expect(service).toBeDefined();
+  it('creates a blood group', async () => {
+    const dto = { nombre: 'O+' } as any;
+    const entity = { id: 1, ...dto } as GrupoSanguineoEntity;
+    repository.create!.mockReturnValue(entity);
+    repository.save!.mockResolvedValue(entity);
+
+    const result = await service.create(dto);
+
+    expect(repository.create).toHaveBeenCalledWith(dto);
+    expect(repository.save).toHaveBeenCalledWith(entity);
+    expect(result).toBe(entity);
+  });
+
+  it('deletes a blood group', async () => {
+    const entity = { id: 1, nombre: 'O+' } as GrupoSanguineoEntity;
+    repository.findOneBy!.mockResolvedValue(entity);
+
+    const result = await service.delete(entity.id);
+
+    expect(repository.remove).toHaveBeenCalledWith(entity);
+    expect(result.message).toContain(entity.nombre);
+  });
+
+  it('returns all blood groups', async () => {
+    const entities = [{ id: 1 } as GrupoSanguineoEntity];
+    repository.find!.mockResolvedValue(entities);
+
+    const result = await service.findAll();
+
+    expect(result).toBe(entities);
+  });
+
+  it('finds a blood group by id', async () => {
+    const entity = { id: 1 } as GrupoSanguineoEntity;
+    repository.findOneBy!.mockResolvedValue(entity);
+
+    const result = await service.findById(1);
+
+    expect(result).toBe(entity);
+  });
+
+  it('throws when blood group not found', async () => {
+    repository.findOneBy!.mockResolvedValue(null);
+
+    await expect(service.findById(1)).rejects.toThrow(NotFoundException);
   });
 });

--- a/src/services/historia-clinica/historia-clinica.service.spec.ts
+++ b/src/services/historia-clinica/historia-clinica.service.spec.ts
@@ -1,18 +1,113 @@
-import { Test, TestingModule } from '@nestjs/testing';
+import { ConflictException } from '@nestjs/common';
+import { createMockRepository } from '../../../test/utils/mock-repository';
 import { HistoriaClinicaService } from './historia-clinica.service';
+import { HistoriaClinicaEntity } from '../../entities/historiaClinica.entity';
+import { PacienteService } from '../paciente/paciente.service';
+import { EmpleadoService } from '../empleado/empleado.service';
+
+const createUser = (email: string) => ({ email } as any);
+
+const createDoctor = (user: any) => ({ user } as any);
 
 describe('HistoriaClinicaService', () => {
+  const repository = createMockRepository<HistoriaClinicaEntity>();
+  const pacienteService = { findOne: jest.fn() } as unknown as PacienteService;
+  const empleadoService = { findByUser: jest.fn() } as unknown as EmpleadoService;
   let service: HistoriaClinicaService;
 
-  beforeEach(async () => {
-    const module: TestingModule = await Test.createTestingModule({
-      providers: [HistoriaClinicaService],
-    }).compile();
-
-    service = module.get<HistoriaClinicaService>(HistoriaClinicaService);
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new HistoriaClinicaService(repository as any, pacienteService, empleadoService);
   });
 
-  it('should be defined', () => {
-    expect(service).toBeDefined();
+  it('creates a historia clinica', async () => {
+    const dto = { paciente: 1, entrada: 'Consulta', observacionExtra: 'N/A' } as any;
+    const paciente = { id: 1 } as any;
+    const doctor = createDoctor('doctor@example.com');
+    const entity = { id: 1 } as HistoriaClinicaEntity;
+    pacienteService.findOne = jest.fn().mockResolvedValue(paciente);
+    empleadoService.findByUser = jest.fn().mockResolvedValue(doctor);
+    repository.create!.mockReturnValue(entity);
+    repository.save!.mockResolvedValue(entity);
+
+    const result = await service.create(dto, createUser('doctor@example.com'));
+
+    expect(pacienteService.findOne).toHaveBeenCalledWith(dto.paciente);
+    expect(empleadoService.findByUser).toHaveBeenCalled();
+    expect(repository.create).toHaveBeenCalled();
+    expect(result).toBe(entity);
+  });
+
+  it('edits a historia clinica within allowed time', async () => {
+    const user = createUser('doctor@example.com');
+    const historia = {
+      id: 1,
+      fechaEntrada: new Date(Date.now() - 5 * 60 * 1000),
+      doctor: createDoctor(user),
+    } as HistoriaClinicaEntity;
+    const dto = { observacionExtra: 'Actualizado' } as any;
+    repository.findOneBy!.mockResolvedValue(historia);
+    repository.save!.mockResolvedValue({ ...historia, ...dto });
+
+    const result = await service.edit(historia.id, dto, user);
+
+    expect(repository.merge).toHaveBeenCalledWith(historia, dto);
+    expect(repository.save).toHaveBeenCalledWith(historia);
+    expect(result.observacionExtra).toBe('Actualizado');
+  });
+
+  it('throws if editing history of another doctor', async () => {
+    const user = createUser('other@example.com');
+    const historia = {
+      id: 1,
+      fechaEntrada: new Date(),
+      doctor: createDoctor(createUser('doctor@example.com')),
+    } as HistoriaClinicaEntity;
+    repository.findOneBy!.mockResolvedValue(historia);
+
+    await expect(service.edit(historia.id, {}, user)).rejects.toThrow(ConflictException);
+  });
+
+  it('throws if editing after 15 minutes', async () => {
+    const user = createUser('doctor@example.com');
+    const historia = {
+      id: 1,
+      fechaEntrada: new Date(Date.now() - 20 * 60 * 1000),
+      doctor: createDoctor(user),
+    } as HistoriaClinicaEntity;
+    repository.findOneBy!.mockResolvedValue(historia);
+
+    await expect(service.edit(historia.id, {}, user)).rejects.toThrow(ConflictException);
+  });
+
+  it('finds histories by patient', async () => {
+    const entities = [{ id: 1 } as HistoriaClinicaEntity];
+    repository.find!.mockResolvedValue(entities);
+
+    const result = await service.findByPatient(1);
+
+    expect(repository.find).toHaveBeenCalledWith({
+      where: {
+        paciente: {
+          id: 1,
+        },
+      },
+    });
+    expect(result).toBe(entities);
+  });
+
+  it('finds one history', async () => {
+    const entity = { id: 1 } as HistoriaClinicaEntity;
+    repository.findOneBy!.mockResolvedValue(entity);
+
+    const result = await service.findOne(1);
+
+    expect(result).toBe(entity);
+  });
+
+  it('throws when history not found', async () => {
+    repository.findOneBy!.mockResolvedValue(null);
+
+    await expect(service.findOne(1)).rejects.toThrow('El id: 1 no corresponde a ninguna historia clinica');
   });
 });

--- a/src/services/paciente/paciente.service.spec.ts
+++ b/src/services/paciente/paciente.service.spec.ts
@@ -1,18 +1,115 @@
-import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException } from '@nestjs/common';
+import { createMockRepository } from '../../../test/utils/mock-repository';
 import { PacienteService } from './paciente.service';
+import { PacienteEntity } from '../../entities/paciente.entity';
+import { GrupoSanguineoService } from '../grupo-sanguineo/grupo-sanguineo.service';
+import { PersonaService } from '../persona/persona.service';
+
+const createManager = () => {
+  const repository = {
+    save: jest.fn(),
+  };
+  return {
+    getRepository: jest.fn().mockReturnValue(repository),
+    repository,
+  };
+};
 
 describe('PacienteService', () => {
+  const repository = createMockRepository<PacienteEntity>();
+  const grupoSanguineoService = {
+    findById: jest.fn(),
+  } as unknown as GrupoSanguineoService;
+  const personaService = {
+    create: jest.fn(),
+  } as unknown as PersonaService;
+  const dataSource = {
+    transaction: jest.fn(),
+  } as any;
   let service: PacienteService;
 
-  beforeEach(async () => {
-    const module: TestingModule = await Test.createTestingModule({
-      providers: [PacienteService],
-    }).compile();
-
-    service = module.get<PacienteService>(PacienteService);
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new PacienteService(grupoSanguineoService, personaService, repository as any, dataSource);
   });
 
-  it('should be defined', () => {
-    expect(service).toBeDefined();
+  it('creates a patient using a transaction', async () => {
+    const dto = { idGrupoSanguineo: 1, altura: 180, peso: 80, observaciones: 'N/A' } as any;
+    const grupo = { id: 1 } as any;
+    const persona = { id: 2 } as any;
+    const paciente = { id: 3 } as PacienteEntity;
+    const manager = createManager();
+    (manager.repository.save as jest.Mock).mockResolvedValue(paciente);
+    grupoSanguineoService.findById = jest.fn().mockResolvedValue(grupo);
+    personaService.create = jest.fn().mockResolvedValue(persona);
+    repository.create!.mockReturnValue(paciente);
+    dataSource.transaction.mockImplementation(async (cb: any) => cb(manager));
+
+    const result = await service.create(dto);
+
+    expect(grupoSanguineoService.findById).toHaveBeenCalledWith(dto.idGrupoSanguineo);
+    expect(personaService.create).toHaveBeenCalledWith(dto, manager);
+    expect(repository.create).toHaveBeenCalledWith({
+      altura: dto.altura,
+      peso: dto.peso,
+      observaciones: dto.observaciones,
+      persona,
+      grupoSanguineo: grupo,
+    });
+    expect(manager.getRepository).toHaveBeenCalled();
+    expect(result).toBe(paciente);
+  });
+
+  it('edits a patient updating blood group', async () => {
+    const dto = { idGrupoSanguineo: 2, observaciones: 'Updated' } as any;
+    const existing = { id: 1, grupoSanguineo: { id: 1 } } as PacienteEntity;
+    const newGroup = { id: 2 } as any;
+    repository.findOne!.mockResolvedValue(existing);
+    grupoSanguineoService.findById = jest.fn().mockResolvedValue(newGroup);
+    repository.save!.mockResolvedValue({ ...existing, ...dto, grupoSanguineo: newGroup });
+
+    const result = await service.edit(existing.id, dto);
+
+    expect(grupoSanguineoService.findById).toHaveBeenCalledWith(dto.idGrupoSanguineo);
+    expect(repository.merge).toHaveBeenCalledWith(existing, dto);
+    expect(repository.save).toHaveBeenCalledWith(existing);
+    expect(result.grupoSanguineo).toBe(newGroup);
+  });
+
+  it('edits a patient without changing blood group', async () => {
+    const dto = { observaciones: 'Updated' } as any;
+    const existing = { id: 1, grupoSanguineo: { id: 1 } } as PacienteEntity;
+    repository.findOne!.mockResolvedValue(existing);
+    repository.save!.mockResolvedValue({ ...existing, ...dto });
+
+    const result = await service.edit(existing.id, dto);
+
+    expect(grupoSanguineoService.findById).not.toHaveBeenCalled();
+    expect(repository.save).toHaveBeenCalledWith(existing);
+    expect(result.observaciones).toBe('Updated');
+  });
+
+  it('finds a patient by id', async () => {
+    const entity = { id: 1 } as PacienteEntity;
+    repository.findOne!.mockResolvedValue(entity);
+
+    const result = await service.findOne(1);
+
+    expect(result).toBe(entity);
+  });
+
+  it('throws when patient not found', async () => {
+    repository.findOne!.mockResolvedValue(null);
+
+    await expect(service.findOne(1)).rejects.toThrow(NotFoundException);
+  });
+
+  it('returns all patients', async () => {
+    const entities = [{ id: 1 } as PacienteEntity];
+    repository.find!.mockResolvedValue(entities);
+
+    const result = await service.findAll();
+
+    expect(result).toBe(entities);
   });
 });

--- a/src/services/permissions/permissions.service.spec.ts
+++ b/src/services/permissions/permissions.service.spec.ts
@@ -1,18 +1,73 @@
-import { Test, TestingModule } from '@nestjs/testing';
+import { createMockRepository } from '../../../test/utils/mock-repository';
 import { PermissionsService } from './permissions.service';
+import { PermissionEntity } from '../../entities/permission.entity';
 
 describe('PermissionsService', () => {
+  const repository = createMockRepository<PermissionEntity>();
   let service: PermissionsService;
 
-  beforeEach(async () => {
-    const module: TestingModule = await Test.createTestingModule({
-      providers: [PermissionsService],
-    }).compile();
-
-    service = module.get<PermissionsService>(PermissionsService);
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new PermissionsService(repository as any);
   });
 
-  it('should be defined', () => {
-    expect(service).toBeDefined();
+  it('creates a permission', async () => {
+    const dto = { code: 'user:create', description: 'Create user' } as any;
+    const entity = { id: 1, ...dto } as PermissionEntity;
+    repository.create!.mockReturnValue(entity);
+    repository.save!.mockResolvedValue(entity);
+
+    const result = await service.create(dto);
+
+    expect(repository.create).toHaveBeenCalledWith(dto);
+    expect(repository.save).toHaveBeenCalledWith(entity);
+    expect(result).toBe(entity);
+  });
+
+  it('updates a permission', async () => {
+    const entity = { id: 1, code: 'user:create' } as PermissionEntity;
+    const dto = { code: 'user:update' } as any;
+    repository.findOneBy!.mockResolvedValue(entity);
+    repository.save!.mockResolvedValue({ ...entity, ...dto });
+
+    const result = await service.update(entity.id, dto);
+
+    expect(repository.merge).toHaveBeenCalledWith(entity, dto);
+    expect(repository.save).toHaveBeenCalledWith(entity);
+    expect(result).toEqual({ ...entity, ...dto });
+  });
+
+  it('deletes a permission', async () => {
+    const entity = { id: 1, code: 'user:create' } as PermissionEntity;
+    repository.findOneBy!.mockResolvedValue(entity);
+
+    const result = await service.delete(entity.id);
+
+    expect(repository.remove).toHaveBeenCalledWith(entity);
+    expect(result.message).toContain(entity.code);
+  });
+
+  it('finds a permission by id', async () => {
+    const entity = { id: 1 } as PermissionEntity;
+    repository.findOneBy!.mockResolvedValue(entity);
+
+    const result = await service.findOne(1);
+
+    expect(result).toBe(entity);
+  });
+
+  it('throws when permission not found', async () => {
+    repository.findOneBy!.mockResolvedValue(null);
+
+    await expect(service.findOne(1)).rejects.toThrow('No existe el permiso con el id: 1');
+  });
+
+  it('returns all permissions', async () => {
+    const entities = [{ id: 1 } as PermissionEntity];
+    repository.find!.mockResolvedValue(entities);
+
+    const result = await service.findAll();
+
+    expect(result).toBe(entities);
   });
 });

--- a/src/services/persona/persona.service.spec.ts
+++ b/src/services/persona/persona.service.spec.ts
@@ -1,18 +1,75 @@
-import { Test, TestingModule } from '@nestjs/testing';
+import { createMockRepository } from '../../../test/utils/mock-repository';
 import { PersonaService } from './persona.service';
+import { PersonaEntity } from '../../entities/persona.entity';
 
 describe('PersonaService', () => {
+  const repository = createMockRepository<PersonaEntity>();
   let service: PersonaService;
 
-  beforeEach(async () => {
-    const module: TestingModule = await Test.createTestingModule({
-      providers: [PersonaService],
-    }).compile();
-
-    service = module.get<PersonaService>(PersonaService);
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new PersonaService(repository as any);
   });
 
-  it('should be defined', () => {
-    expect(service).toBeDefined();
+  it('creates a persona without manager', async () => {
+    const dto = {
+      nombre: 'Juan',
+      apellido: 'Pérez',
+      fechaNacimiento: new Date(),
+      tipoDocumento: 'DNI',
+      nroDocumento: '123',
+      telefono: '555',
+    } as any;
+    const entity = { id: 1, ...dto } as PersonaEntity;
+    repository.create!.mockReturnValue(entity);
+    repository.save!.mockResolvedValue(entity);
+
+    const result = await service.create(dto);
+
+    expect(repository.create).toHaveBeenCalledWith({
+      nombre: dto.nombre,
+      apellido: dto.apellido,
+      fechaNacimiento: dto.fechaNacimiento,
+      tipoDocumento: dto.tipoDocumento,
+      numeroDocumento: dto.nroDocumento,
+      telefono: dto.telefono,
+    });
+    expect(repository.save).toHaveBeenCalledWith(entity);
+    expect(result).toBe(entity);
+  });
+
+  it('creates a persona using manager repository', async () => {
+    const createMock = jest.fn().mockReturnValue({ id: 1 } as PersonaEntity);
+    const saveMock = jest.fn().mockResolvedValue({ id: 1 } as PersonaEntity);
+    const manager = {
+      getRepository: jest.fn().mockReturnValue({ create: createMock, save: saveMock }),
+    } as any;
+
+    const dto = { nombre: 'Ana', apellido: 'López' } as any;
+
+    const result = await service.create(dto, manager);
+
+    expect(manager.getRepository).toHaveBeenCalled();
+    expect(createMock).toHaveBeenCalled();
+    expect(saveMock).toHaveBeenCalled();
+    expect(result).toEqual({ id: 1 });
+  });
+
+  it('edits a persona', async () => {
+    const entity = { id: 1, nombre: 'Juan' } as PersonaEntity;
+    const dto = { nombre: 'Pedro' } as any;
+    repository.findOneBy!.mockResolvedValue(entity);
+    repository.save!.mockResolvedValue({ ...entity, ...dto });
+
+    const result = await service.edit(entity.id, dto);
+
+    expect(repository.merge).toHaveBeenCalledWith(entity, dto);
+    expect(repository.save).toHaveBeenCalledWith(entity);
+    expect(result).toEqual({ ...entity, ...dto });
+  });
+
+  it('throws when finding non existing persona', async () => {
+    repository.findOneBy!.mockResolvedValue(null);
+    await expect((service as any).findOne(1)).rejects.toThrow('No existe la persona con el id: 1');
   });
 });

--- a/src/services/procedimiento/procedimiento.service.spec.ts
+++ b/src/services/procedimiento/procedimiento.service.spec.ts
@@ -1,98 +1,75 @@
-
-import { Test, TestingModule } from '@nestjs/testing';
-import { ProcedimientoService } from './procedimiento.service';
-import { getRepositoryToken } from '@nestjs/typeorm';
-import { ProcedimientoEntity } from '../../entities/procedimiento.entity';
-import { Repository } from 'typeorm';
 import { NotFoundException } from '@nestjs/common';
-
-const procedimientoArray = [
-  { id: 1, nombre: 'Proc1', descripcion: 'Desc1', duracion: 30 },
-  { id: 2, nombre: 'Proc2', descripcion: 'Desc2', duracion: 45 },
-];
+import { createMockRepository } from '../../../test/utils/mock-repository';
+import { ProcedimientoService } from './procedimiento.service';
+import { ProcedimientoEntity } from '../../entities/procedimiento.entity';
 
 describe('ProcedimientoService', () => {
+  const repository = createMockRepository<ProcedimientoEntity>();
   let service: ProcedimientoService;
-  let repo: Repository<ProcedimientoEntity>;
 
-  const mockRepo = {
-    create: jest.fn(dto => ({ ...dto })),
-    save: jest.fn(entity => Promise.resolve({ id: 1, ...entity })),
-    merge: jest.fn((entity, dto) => ({ ...entity, ...dto })),
-    remove: jest.fn(entity => Promise.resolve(entity)),
-    find: jest.fn(() => Promise.resolve(procedimientoArray)),
-    findOneBy: jest.fn(({ id }) =>
-      Promise.resolve(procedimientoArray.find(p => p.id === id) || null)
-    ),
-  };
-
-  beforeEach(async () => {
-    const module: TestingModule = await Test.createTestingModule({
-      providers: [
-        ProcedimientoService,
-        {
-          provide: getRepositoryToken(ProcedimientoEntity),
-          useValue: mockRepo,
-        },
-      ],
-    }).compile();
-
-    service = module.get<ProcedimientoService>(ProcedimientoService);
-    repo = module.get<Repository<ProcedimientoEntity>>(getRepositoryToken(ProcedimientoEntity));
-
+  beforeEach(() => {
     jest.clearAllMocks();
+    service = new ProcedimientoService(repository as any);
   });
 
-  it('should be defined', () => {
-    expect(service).toBeDefined();
+  it('creates a procedure', async () => {
+    const dto = { nombre: 'Consulta', duracion: 30 } as any;
+    const entity = { id: 1, ...dto } as ProcedimientoEntity;
+    repository.create!.mockReturnValue(entity);
+    repository.save!.mockResolvedValue(entity);
+
+    const result = await service.create(dto);
+
+    expect(repository.create).toHaveBeenCalledWith(dto);
+    expect(repository.save).toHaveBeenCalledWith(entity);
+    expect(result).toBe(entity);
   });
 
-  describe('create', () => {
-    it('should create and save a procedimiento', async () => {
-      const dto = { nombre: 'Nuevo', descripcion: 'Desc', duracion: 20 };
-      const result = await service.create(dto as any);
-      expect(repo.create).toHaveBeenCalledWith(dto);
-      expect(repo.save).toHaveBeenCalledWith(dto);
-      expect(result).toEqual({ id: 1, ...dto });
-    });
+  it('patches a procedure', async () => {
+    const entity = { id: 1, nombre: 'Consulta', duracion: 30 } as ProcedimientoEntity;
+    const dto = { duracion: 45 } as any;
+    repository.findOneBy!.mockResolvedValue(entity);
+    repository.merge!.mockReturnValue({ ...entity, ...dto });
+    repository.save!.mockResolvedValue({ ...entity, ...dto });
+
+    const result = await service.patch(entity.id, dto);
+
+    expect(repository.merge).toHaveBeenCalledWith(entity, dto);
+    expect(repository.save).toHaveBeenCalledWith({ ...entity, ...dto });
+    expect(result).toEqual({ ...entity, ...dto });
   });
 
-  describe('findAll', () => {
-    it('should return all procedimientos', async () => {
-      const result = await service.findAll();
-      expect(result).toEqual(procedimientoArray);
-      expect(repo.find).toHaveBeenCalled();
-    });
+  it('deletes a procedure', async () => {
+    const entity = { id: 1, nombre: 'Consulta' } as ProcedimientoEntity;
+    repository.findOneBy!.mockResolvedValue(entity);
+
+    const result = await service.delete(entity.id);
+
+    expect(repository.remove).toHaveBeenCalledWith(entity);
+    expect(result.message).toContain(entity.nombre);
   });
 
-  describe('findOne', () => {
-    it('should return a procedimiento by id', async () => {
-      const result = await service.findOne(1);
-      expect(result).toEqual(procedimientoArray[0]);
-      expect(repo.findOneBy).toHaveBeenCalledWith({ id: 1 });
-    });
-    it('should throw NotFoundException if not found', async () => {
-      await expect(service.findOne(999)).rejects.toThrow(NotFoundException);
-    });
+  it('finds all procedures', async () => {
+    const entities = [{ id: 1 } as ProcedimientoEntity];
+    repository.find!.mockResolvedValue(entities);
+
+    const result = await service.findAll();
+
+    expect(result).toBe(entities);
   });
 
-  describe('patch', () => {
-    it('should patch and save a procedimiento', async () => {
-      const patchDto = { descripcion: 'Modificado' };
-      jest.spyOn(service, 'findOne').mockResolvedValueOnce(procedimientoArray[0] as any);
-      const result = await service.patch(1, patchDto as any);
-      expect(repo.merge).toHaveBeenCalledWith(procedimientoArray[0], patchDto);
-      expect(repo.save).toHaveBeenCalledWith({ ...procedimientoArray[0], ...patchDto });
-      expect(result).toEqual({ ...procedimientoArray[0], ...patchDto });
-    });
+  it('finds one procedure', async () => {
+    const entity = { id: 1 } as ProcedimientoEntity;
+    repository.findOneBy!.mockResolvedValue(entity);
+
+    const result = await service.findOne(1);
+
+    expect(result).toBe(entity);
   });
 
-  describe('delete', () => {
-    it('should remove a procedimiento and return message', async () => {
-      jest.spyOn(service, 'findOne').mockResolvedValueOnce(procedimientoArray[0] as any);
-      const result = await service.delete(1);
-      expect(repo.remove).toHaveBeenCalledWith(procedimientoArray[0]);
-      expect(result).toEqual({ message: `Procedimiento: ${procedimientoArray[0].nombre} eliminado correctamente` });
-    });
+  it('throws when procedure not found', async () => {
+    repository.findOneBy!.mockResolvedValue(null);
+
+    await expect(service.findOne(1)).rejects.toThrow(NotFoundException);
   });
 });

--- a/src/services/roles/roles.service.spec.ts
+++ b/src/services/roles/roles.service.spec.ts
@@ -1,18 +1,99 @@
-import { Test, TestingModule } from '@nestjs/testing';
+import { createMockRepository } from '../../../test/utils/mock-repository';
 import { RolesService } from './roles.service';
+import { RoleEntity } from '../../entities/role.entity';
+import { PermissionsService } from '../permissions/permissions.service';
 
 describe('RolesService', () => {
+  const repository = createMockRepository<RoleEntity>();
+  const permissionsService = {
+    findOne: jest.fn(),
+  } as unknown as PermissionsService;
   let service: RolesService;
 
-  beforeEach(async () => {
-    const module: TestingModule = await Test.createTestingModule({
-      providers: [RolesService],
-    }).compile();
-
-    service = module.get<RolesService>(RolesService);
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new RolesService(repository as any, permissionsService);
   });
 
-  it('should be defined', () => {
-    expect(service).toBeDefined();
+  it('creates a role', async () => {
+    const dto = { name: 'Admin' } as any;
+    const entity = { id: 1, ...dto } as RoleEntity;
+    repository.create!.mockReturnValue(entity);
+    repository.save!.mockResolvedValue(entity);
+
+    const result = await service.create(dto);
+
+    expect(repository.create).toHaveBeenCalledWith(dto);
+    expect(repository.save).toHaveBeenCalledWith(entity);
+    expect(result).toBe(entity);
+  });
+
+  it('updates a role', async () => {
+    const entity = { id: 1, name: 'User' } as RoleEntity;
+    const dto = { name: 'Admin' } as any;
+    repository.findOneBy!.mockResolvedValue(entity);
+    repository.save!.mockResolvedValue({ ...entity, ...dto });
+
+    const result = await service.update(entity.id, dto);
+
+    expect(repository.merge).toHaveBeenCalledWith(entity, dto);
+    expect(repository.save).toHaveBeenCalledWith(entity);
+    expect(result).toEqual({ ...entity, ...dto });
+  });
+
+  it('deletes a role', async () => {
+    const entity = { id: 1, name: 'User' } as RoleEntity;
+    repository.findOneBy!.mockResolvedValue(entity);
+
+    const result = await service.delete(entity.id);
+
+    expect(repository.remove).toHaveBeenCalledWith(entity);
+    expect(result.message).toContain(entity.name);
+  });
+
+  it('returns all roles', async () => {
+    const entities = [{ id: 1 } as RoleEntity];
+    repository.find!.mockResolvedValue(entities);
+
+    const result = await service.findAll();
+
+    expect(result).toBe(entities);
+  });
+
+  it('finds a role by id', async () => {
+    const entity = { id: 1 } as RoleEntity;
+    repository.findOneBy!.mockResolvedValue(entity);
+
+    const result = await service.findOne(1);
+
+    expect(result).toBe(entity);
+  });
+
+  it('assigns permissions to a role', async () => {
+    const permission = { id: 1 } as any;
+    const role = { id: 1, permissions: [] } as RoleEntity;
+    repository.findOneBy!.mockResolvedValue(role);
+    permissionsService.findOne = jest.fn().mockResolvedValue(permission);
+    repository.save!.mockResolvedValue({ ...role, permissions: [permission] });
+
+    const result = await service.assignPermissions(1, { permissionCodes: [1] } as any);
+
+    expect(permissionsService.findOne).toHaveBeenCalledWith(1);
+    expect(repository.save).toHaveBeenCalledWith(role);
+    expect(role.permissions).toContain(permission);
+    expect(result.permissions).toContain(permission);
+  });
+
+  it('removes a permission from a role', async () => {
+    const permission = { id: 1 } as any;
+    const role = { id: 1, permissions: [permission, { id: 2 } as any] } as RoleEntity;
+    repository.findOneBy!.mockResolvedValue(role);
+    permissionsService.findOne = jest.fn().mockResolvedValue(permission);
+
+    const result = await service.removePermission(1, 1);
+
+    expect(repository.save).toHaveBeenCalledWith(role);
+    expect(role.permissions).toEqual([{ id: 2 }]);
+    expect(result.message).toBe('Permiso eliminado');
   });
 });

--- a/src/services/tipo-empleado/tipo-empleado.service.spec.ts
+++ b/src/services/tipo-empleado/tipo-empleado.service.spec.ts
@@ -1,18 +1,74 @@
-import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException } from '@nestjs/common';
+import { createMockRepository } from '../../../test/utils/mock-repository';
 import { TipoEmpleadoService } from './tipo-empleado.service';
+import { TipoEmpleadoEntity } from '../../entities/tipoEmpleado.entity';
 
 describe('TipoEmpleadoService', () => {
+  const repository = createMockRepository<TipoEmpleadoEntity>();
   let service: TipoEmpleadoService;
 
-  beforeEach(async () => {
-    const module: TestingModule = await Test.createTestingModule({
-      providers: [TipoEmpleadoService],
-    }).compile();
-
-    service = module.get<TipoEmpleadoService>(TipoEmpleadoService);
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new TipoEmpleadoService(repository as any);
   });
 
-  it('should be defined', () => {
-    expect(service).toBeDefined();
+  it('creates a tipo empleado', async () => {
+    const dto = { nombre: 'Doctor' } as any;
+    const entity = { id: 1, ...dto } as TipoEmpleadoEntity;
+    repository.create!.mockReturnValue(entity);
+    repository.save!.mockResolvedValue(entity);
+
+    const result = await service.create(dto);
+
+    expect(repository.create).toHaveBeenCalledWith(dto);
+    expect(repository.save).toHaveBeenCalledWith(entity);
+    expect(result).toBe(entity);
+  });
+
+  it('edits a tipo empleado', async () => {
+    const entity = { id: 1, nombre: 'Doctor' } as TipoEmpleadoEntity;
+    const dto = { nombre: 'Enfermero' } as any;
+    repository.findOneBy!.mockResolvedValue(entity);
+    repository.save!.mockResolvedValue({ ...entity, ...dto });
+
+    const result = await service.edit(entity.id, dto);
+
+    expect(repository.merge).toHaveBeenCalledWith(entity, dto);
+    expect(repository.save).toHaveBeenCalledWith(entity);
+    expect(result).toEqual({ ...entity, ...dto });
+  });
+
+  it('deletes a tipo empleado', async () => {
+    const entity = { id: 1, nombre: 'Doctor' } as TipoEmpleadoEntity;
+    repository.findOneBy!.mockResolvedValue(entity);
+
+    const result = await service.delete(entity.id);
+
+    expect(repository.remove).toHaveBeenCalledWith(entity);
+    expect(result.message).toContain(entity.nombre);
+  });
+
+  it('returns all tipos de empleado', async () => {
+    const entities = [{ id: 1 } as TipoEmpleadoEntity];
+    repository.find!.mockResolvedValue(entities);
+
+    const result = await service.findAll();
+
+    expect(result).toBe(entities);
+  });
+
+  it('finds a tipo empleado by id', async () => {
+    const entity = { id: 1 } as TipoEmpleadoEntity;
+    repository.findOneBy!.mockResolvedValue(entity);
+
+    const result = await service.findOne(1);
+
+    expect(result).toBe(entity);
+  });
+
+  it('throws when tipo empleado not found', async () => {
+    repository.findOneBy!.mockResolvedValue(null);
+
+    await expect(service.findOne(1)).rejects.toThrow(NotFoundException);
   });
 });

--- a/src/services/turno/turno.service.spec.ts
+++ b/src/services/turno/turno.service.spec.ts
@@ -1,247 +1,97 @@
-import { Test, TestingModule } from '@nestjs/testing';
 import { TurnoService } from './turno.service';
-import { getRepositoryToken } from '@nestjs/typeorm';
-import { TurnoEntity } from '../../entities/turno.entity';
-import { DataSource, Repository } from 'typeorm';
-import { ConflictException } from '@nestjs/common';
-import { ProcedimientoService } from '../procedimiento/procedimiento.service';
-import { EmpleadoService } from '../empleado/empleado.service';
-import { PacienteService } from '../paciente/paciente.service';
-import { EspecialidadService } from '../especialidad/especialidad.service';
-import { EstadoTurnoService } from '../estado-turno/estado-turno.service';
 import { CreateTurnoDTO } from '../../interfaces/create/create-turno.dto';
-import { ProcedimientoEntity } from '../../entities/procedimiento.entity';
-import { EmpleadoEntity } from '../../entities/empleado.entity';
-import { PacienteEntity } from '../../entities/paciente.entity';
-import { EspecialidadEntity } from '../../entities/especialidad.entity';
-import { EstadoTurnoEntity } from '../../entities/estadoTurno.entity';
 
-// Mock de todas las dependencias del TurnoService
-const mockTurnoRepository = {
-  create: jest.fn(),
-  save: jest.fn(),
-};
-
-const mockProcedimientoService = {
-  findOne: jest.fn(),
-};
-
-const mockEstadoTurnoService = {
-  findOne: jest.fn(),
-};
-
-const mockEmpleadoService = {
-  findById: jest.fn(),
-};
-
-const mockPacienteService = {
-  findOne: jest.fn(),
-};
-
-const mockEspecialidadService = {
-  findOne: jest.fn(),
-};
-
-// Mock de la transacción de la base de datos
-const mockDataSource = {
-  transaction: jest.fn((mode, callback) => callback({
+const createManager = () => {
+  const repository = {
+    create: jest.fn(),
+    save: jest.fn(),
+  };
+  return {
     query: jest.fn(),
-    getRepository: jest.fn(() => mockTurnoRepository),
-  })),
-  query: jest.fn(), // Añadimos mock de query a mockDataSource
+    getRepository: jest.fn().mockReturnValue(repository),
+    repository,
+  };
 };
 
 describe('TurnoService', () => {
+  const procedimientoService = { findOne: jest.fn() } as any;
+  const estadoTurnoService = { findOne: jest.fn() } as any;
+  const empleadoService = { findById: jest.fn() } as any;
+  const pacienteService = { findOne: jest.fn() } as any;
+  const especialidadService = { findOne: jest.fn() } as any;
+  const dataSource = { transaction: jest.fn() } as any;
+  const turnoRepository = {} as any;
   let service: TurnoService;
-  let turnoRepository: Repository<TurnoEntity>;
-  let procedimientoService: ProcedimientoService;
-  let dataSource: DataSource;
 
-  beforeEach(async () => {
-    const module: TestingModule = await Test.createTestingModule({
-      providers: [
-        TurnoService,
-        {
-          provide: getRepositoryToken(TurnoEntity),
-          useValue: mockTurnoRepository,
-        },
-        {
-          provide: ProcedimientoService,
-          useValue: mockProcedimientoService,
-        },
-        {
-          provide: EstadoTurnoService,
-          useValue: mockEstadoTurnoService,
-        },
-        {
-          provide: EmpleadoService,
-          useValue: mockEmpleadoService,
-        },
-        {
-          provide: PacienteService,
-          useValue: mockPacienteService,
-        },
-        {
-          provide: EspecialidadService,
-          useValue: mockEspecialidadService,
-        },
-        {
-          provide: DataSource,
-          useValue: mockDataSource,
-        },
-      ],
-    }).compile();
-
-    service = module.get<TurnoService>(TurnoService);
-    turnoRepository = module.get<Repository<TurnoEntity>>(getRepositoryToken(TurnoEntity));
-    procedimientoService = module.get<ProcedimientoService>(ProcedimientoService);
-    dataSource = module.get<DataSource>(DataSource);
-
-    jest.spyOn(service as any, 'dayKayUTC').mockReturnValue(12345678);
-  });
-
-  afterEach(() => {
+  beforeEach(() => {
     jest.clearAllMocks();
+    service = new TurnoService(
+      turnoRepository,
+      procedimientoService,
+      estadoTurnoService,
+      empleadoService,
+      pacienteService,
+      especialidadService,
+      dataSource,
+    );
   });
 
-  it('debe estar definido', () => {
-    expect(service).toBeDefined();
+  const baseDto: CreateTurnoDTO = {
+    fechaHoraTurno: '2025-10-10T10:00:00Z',
+    motivo: 'Consulta',
+    procedimiento: 1,
+    doctor: 1,
+    paciente: 1,
+    especialidad: 1,
+  } as any;
+
+  it('agends a turno successfully', async () => {
+    const manager = createManager();
+    const procedimiento = { duracion: 30 };
+    const estado = { id: 1 };
+    const doctor = { id: 1 };
+    const paciente = { id: 1 };
+    const especialidad = { id: 1 };
+    const turno = { id: 99 };
+    manager.query.mockImplementation(async (sql: string) => (sql.includes('SELECT 1') ? [] : []));
+    manager.repository.create.mockReturnValue(turno);
+    manager.repository.save.mockResolvedValue(turno);
+    procedimientoService.findOne = jest.fn().mockResolvedValue(procedimiento);
+    estadoTurnoService.findOne = jest.fn().mockResolvedValue(estado);
+    empleadoService.findById = jest.fn().mockResolvedValue(doctor);
+    pacienteService.findOne = jest.fn().mockResolvedValue(paciente);
+    especialidadService.findOne = jest.fn().mockResolvedValue(especialidad);
+    dataSource.transaction.mockImplementation(async (_iso: any, cb: any) => cb(manager));
+
+    const result = await service.agendarTurno(baseDto);
+
+    expect(manager.query).toHaveBeenCalled();
+    expect(manager.repository.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        motivo: baseDto.motivo,
+        procedimiento,
+        doctor,
+        paciente,
+        especialidad,
+      }),
+    );
+    expect(result).toBe(turno);
   });
 
-  describe('agendarTurno', () => {
-    it('debe agendar un turno exitosamente si no hay solapamiento', async () => {
-      // Arrange
-      const mockDto: CreateTurnoDTO = {
-        fechaHoraTurno: '2025-10-10T10:00:00Z',
-        motivo: 'Control anual',
-        procedimiento: 1,
-        doctor: 1,
-        paciente: 1,
-        especialidad: 1,
-        estado: 1,
-      };
+  it('throws when date is invalid', async () => {
+    const dto = { ...baseDto, fechaHoraTurno: 'invalid' };
+    dataSource.transaction.mockImplementation(async (_iso: any, cb: any) => cb(createManager()));
 
-      const mockProcedimiento: ProcedimientoEntity = {
-        id: 1,
-        nombre: 'Limpieza dental',
-        duracion: 30, // 30 minutos
-      } as ProcedimientoEntity;
+    await expect(service.agendarTurno(dto)).rejects.toThrow('FechaHora invalida');
+  });
 
-  const mockEstado: EstadoTurnoEntity = { id: 1, nombre: 'Pendiente', descripcion: '' } as EstadoTurnoEntity;
-  const mockDoctor: EmpleadoEntity = ({
-    id: 1,
-    nombre: 'Dr. Smith',
-    tipoEmpleado: null,
-    persona: null,
-    user: null,
-    especialidad: null,
-    procedimientos: [],
-    consultorio: null,
-    historiasClinicas: [],
-    turnos: [],
-  } as unknown) as EmpleadoEntity;
-  const mockPaciente: PacienteEntity = ({
-    id: 1,
-    nombre: 'John Doe',
-    altura: 0,
-    peso: 0,
-    observaciones: '',
-    persona: null,
-    grupoSanguineo: null,
-    historiasClinicas: [],
-    turnos: [],
-  } as unknown) as PacienteEntity;
-  const mockEspecialidad: EspecialidadEntity = { id: 1, nombre: 'Odontología' } as EspecialidadEntity;
+  it('throws when doctor already has appointment', async () => {
+    const manager = createManager();
+    const procedimiento = { duracion: 30 };
+    procedimientoService.findOne = jest.fn().mockResolvedValue(procedimiento);
+    manager.query.mockImplementation(async (sql: string) => (sql.includes('SELECT 1') ? [{ id: 1 }] : []));
+    dataSource.transaction.mockImplementation(async (_iso: any, cb: any) => cb(manager));
 
-      const mockNuevoTurno: TurnoEntity = {
-        fechaRegistro: new Date(),
-        fechaHoraTurno: new Date(mockDto.fechaHoraTurno),
-        motivo: mockDto.motivo,
-        procedimiento: mockProcedimiento,
-        estado: mockEstado,
-        doctor: mockDoctor,
-        paciente: mockPaciente,
-        especialidad: mockEspecialidad,
-      } as TurnoEntity;
-
-      (procedimientoService.findOne as jest.Mock).mockResolvedValue(mockProcedimiento);
-      (mockDataSource.transaction as jest.Mock).mockImplementation(async (mode, callback) => {
-        const manager = {
-          query: jest.fn()
-            .mockResolvedValueOnce([]) // No solapamiento, primera llamada a la consulta SQL
-            .mockResolvedValue([]), // No solapamiento, segunda llamada a la consulta SQL
-          getRepository: jest.fn(() => mockTurnoRepository),
-        };
-        return await callback(manager);
-      });
-      (mockEstadoTurnoService.findOne as jest.Mock).mockResolvedValue(mockEstado);
-      (mockEmpleadoService.findById as jest.Mock).mockResolvedValue(mockDoctor);
-      (mockPacienteService.findOne as jest.Mock).mockResolvedValue(mockPaciente);
-      (mockEspecialidadService.findOne as jest.Mock).mockResolvedValue(mockEspecialidad);
-      (mockTurnoRepository.create as jest.Mock).mockReturnValue(mockNuevoTurno);
-      (mockTurnoRepository.save as jest.Mock).mockResolvedValue(mockNuevoTurno);
-
-      // Act
-      const result = await service.agendarTurno(mockDto);
-
-      // Assert
-      expect(result).toEqual(mockNuevoTurno);
-      expect(procedimientoService.findOne).toHaveBeenCalledWith(mockDto.procedimiento);
-      expect(mockTurnoRepository.create).toHaveBeenCalledWith(expect.objectContaining({ motivo: mockDto.motivo }));
-      expect(mockTurnoRepository.save).toHaveBeenCalledWith(mockNuevoTurno);
-    });
-
-    it('debe lanzar un ConflictException si la fecha es invalida', async () => {
-      // Arrange
-      const mockDto: CreateTurnoDTO = {
-        fechaHoraTurno: 'fecha invalida',
-        motivo: 'Control',
-        procedimiento: 1,
-        doctor: 1,
-        paciente: 1,
-        especialidad: 1,
-        estado: 1,
-      };
-
-      // Act & Assert
-      await expect(service.agendarTurno(mockDto)).rejects.toThrow(ConflictException);
-      await expect(service.agendarTurno(mockDto)).rejects.toThrow('FechaHora invalida');
-    });
-
-    it('debe lanzar un ConflictException si el doctor ya tiene un turno en ese horario', async () => {
-      // Arrange
-      const mockDto: CreateTurnoDTO = {
-        fechaHoraTurno: '2025-10-10T10:00:00Z',
-        motivo: 'Consulta',
-        procedimiento: 1,
-        doctor: 1,
-        paciente: 1,
-        especialidad: 1,
-        estado: 1,
-      };
-      
-      const mockProcedimiento: ProcedimientoEntity = {
-        id: 1,
-        nombre: 'Limpieza dental',
-        duracion: 30, // 30 minutos
-      } as ProcedimientoEntity;
-      
-      (procedimientoService.findOne as jest.Mock).mockResolvedValue(mockProcedimiento);
-      (mockDataSource.transaction as jest.Mock).mockImplementation(async (mode, callback) => {
-        const manager = {
-          query: jest.fn()
-            .mockResolvedValueOnce([{ '1': 1 }]) // Simula solapamiento, la primera llamada devuelve un resultado
-            .mockResolvedValue([]),
-          getRepository: jest.fn(() => mockTurnoRepository),
-        };
-        return await callback(manager);
-      });
-
-      // Act & Assert
-      await expect(service.agendarTurno(mockDto)).rejects.toThrow(ConflictException);
-      await expect(service.agendarTurno(mockDto)).rejects.toThrow('El doctor ya tiene un turno en ese horario');
-      expect(procedimientoService.findOne).toHaveBeenCalledWith(mockDto.procedimiento);
-    });
-
+    await expect(service.agendarTurno(baseDto)).rejects.toThrow('El doctor ya tiene un turno en ese horario');
   });
 });

--- a/src/services/users/users.service.spec.ts
+++ b/src/services/users/users.service.spec.ts
@@ -1,109 +1,158 @@
 import { NotFoundException, UnauthorizedException } from '@nestjs/common';
+import { createMockRepository } from '../../../test/utils/mock-repository';
 import { UsersService } from './users.service';
 import { UserEntity } from '../../entities/user.entity';
-jest.mock('bcrypt');
+import { JwtService } from '../../jwt/jwt.service';
+import { RolesService } from '../roles/roles.service';
 import * as bcrypt from 'bcrypt';
 
+jest.mock('bcrypt');
+
 describe('UsersService', () => {
+  const repository = createMockRepository<UserEntity>();
+  const jwtService = {
+    generateToken: jest.fn(),
+    refreshToken: jest.fn(),
+  } as unknown as JwtService;
+  const rolesService = {
+    findOne: jest.fn(),
+  } as unknown as RolesService;
   let service: UsersService;
-  let repo: any;
-  let jwtService: any;
 
   beforeEach(() => {
-    repo = {
-      create: jest.fn(),
-      save: jest.fn(),
-      findOne: jest.fn(),
-    };
-
-    jwtService = {
-      generateToken: jest.fn(),
-      refreshToken: jest.fn(),
-    };
-
-    service = new UsersService(repo as any, jwtService as any);
+    jest.clearAllMocks();
+    service = new UsersService(repository as any, jwtService, rolesService);
   });
 
-  afterEach(() => {
-    jest.restoreAllMocks();
-  });
-
-  it('register should create and save a user', async () => {
-    const email = 'a@b.com';
+  it('registers a new user', async () => {
+    const email = 'user@example.com';
     const password = 'secret';
-    const createdUser = { email, password } as UserEntity;
-    repo.create.mockReturnValue(createdUser);
-    repo.save.mockResolvedValue(createdUser);
+    const user = { id: 1, email, password } as UserEntity;
+    repository.create!.mockReturnValue(user);
+    repository.save!.mockResolvedValue(user);
 
     const result = await service.register(email, password);
 
-    expect(repo.create).toHaveBeenCalledWith({ email, password });
-    expect(repo.save).toHaveBeenCalledWith(createdUser);
-    expect(result).toBe(createdUser);
-  });
-
-  it('findByEmail should return user when found', async () => {
-    const user = { email: 'x@y.com', roles: [] } as unknown as UserEntity;
-    repo.findOne.mockResolvedValue(user);
-
-    const result = await service.findByEmail('x@y.com');
-
-    expect(repo.findOne).toHaveBeenCalledWith({ where: { email: 'x@y.com' }, relations: ["roles","roles.permissions"] });
+    expect(repository.create).toHaveBeenCalledWith({ email, password });
+    expect(repository.save).toHaveBeenCalledWith(user);
     expect(result).toBe(user);
   });
 
-  it('findByEmail should throw NotFoundException when not found', async () => {
-    repo.findOne.mockResolvedValue(undefined);
+  it('finds a user by email', async () => {
+    const user = { id: 1, email: 'user@example.com' } as UserEntity;
+    repository.findOne!.mockResolvedValue(user);
 
-    await expect(service.findByEmail('missing@x.com')).rejects.toBeInstanceOf(NotFoundException);
+    const result = await service.findByEmail(user.email);
+
+    expect(repository.findOne).toHaveBeenCalledWith({
+      where: { email: user.email },
+      relations: ['roles', 'roles.permissions'],
+    });
+    expect(result).toBe(user);
   });
 
-  it('login should return tokens when credentials are valid', async () => {
-    const body = { email: 'u@u.com', password: 'plain' };
+  it('throws when user not found by email', async () => {
+    repository.findOne!.mockResolvedValue(null);
+
+    await expect(service.findByEmail('missing@example.com')).rejects.toThrow(NotFoundException);
+  });
+
+  it('logs in user with valid credentials', async () => {
+    const body = { email: 'user@example.com', password: 'plain' } as any;
     const user = { email: body.email, password: 'hashed' } as UserEntity;
-    repo.findOne.mockResolvedValue(user);
-
+    repository.findOne!.mockResolvedValue(user);
     (bcrypt.compareSync as jest.Mock).mockReturnValue(true);
-    jwtService.generateToken.mockImplementation((payload: any, type: string) => `${type}-token`);
+    (jwtService.generateToken as jest.Mock).mockImplementation((payload: any, type: string) => `${type}-token`);
 
-    const tokens = await service.login(body as any);
+    const result = await service.login(body);
 
-    expect(tokens).toHaveProperty('accessToken', 'auth-token');
-    expect(tokens).toHaveProperty('refreshToken', 'refresh-token');
+    expect(result.accessToken).toBe('auth-token');
+    expect(result.refreshToken).toBe('refresh-token');
     expect(jwtService.generateToken).toHaveBeenCalledTimes(2);
   });
 
-  it('login should throw UnauthorizedException when user not found', async () => {
-    const body = { email: 'no@one.com', password: 'x' };
-    repo.findOne.mockResolvedValue(null);
+  it('throws when logging in missing user', async () => {
+    repository.findOne!.mockResolvedValue(null);
 
-    await expect(service.login(body as any)).rejects.toBeInstanceOf(UnauthorizedException);
+    await expect(service.login({ email: 'missing', password: 'x' } as any)).rejects.toThrow(NotFoundException);
   });
 
-  it('login should throw UnauthorizedException on bad password', async () => {
-    const body = { email: 'u@u.com', password: 'plain' };
+  it('throws when password is invalid', async () => {
+    const body = { email: 'user@example.com', password: 'plain' } as any;
     const user = { email: body.email, password: 'hashed' } as UserEntity;
-    repo.findOne.mockResolvedValue(user);
-
+    repository.findOne!.mockResolvedValue(user);
     (bcrypt.compareSync as jest.Mock).mockReturnValue(false);
 
-    await expect(service.login(body as any)).rejects.toBeInstanceOf(UnauthorizedException);
+    await expect(service.login(body)).rejects.toThrow(UnauthorizedException);
   });
 
-  it('canDo should return true when permission exists', async () => {
+  it('validates permissions', async () => {
     const user = { permissionCodes: ['read:users'] } as any;
+
     await expect(service.canDo(user, 'read:users')).resolves.toBe(true);
   });
 
-  it('canDo should throw UnauthorizedException when permission missing', async () => {
+  it('throws when user lacks permission', async () => {
     const user = { permissionCodes: [] } as any;
-    await expect(service.canDo(user, 'write:users')).rejects.toBeInstanceOf(UnauthorizedException);
+
+    await expect(service.canDo(user, 'write:users')).rejects.toThrow(UnauthorizedException);
   });
 
-  it('refreshToken should call jwtService.refreshToken', async () => {
-    jwtService.refreshToken.mockReturnValue('ok');
-    const res = await service.refreshToken('r');
-    expect(jwtService.refreshToken).toHaveBeenCalledWith('r');
-    expect(res).toBe('ok');
+  it('refreshes token', async () => {
+    (jwtService.refreshToken as jest.Mock).mockReturnValue('new-token');
+
+    const result = await service.refreshToken('old-token');
+
+    expect(jwtService.refreshToken).toHaveBeenCalledWith('old-token');
+    expect(result).toBe('new-token');
+  });
+
+  it('assigns roles to a user without roles', async () => {
+    const user = { id: 1, roles: [] } as UserEntity;
+    const role = { id: 2 } as any;
+    repository.findOne!.mockResolvedValueOnce(user);
+    rolesService.findOne = jest.fn().mockResolvedValue(role);
+    repository.save!.mockResolvedValue({ ...user, roles: [role] });
+
+    const result = await service.assignRoles(1, { roleIds: [2] } as any);
+
+    expect(rolesService.findOne).toHaveBeenCalledWith(2);
+    expect(repository.save).toHaveBeenCalledWith(user);
+    expect(result.roles).toContain(role);
+  });
+
+  it('assigns roles appending to existing roles', async () => {
+    const existingRole = { id: 1 } as any;
+    const newRole = { id: 2 } as any;
+    const user = { id: 1, roles: [existingRole] } as UserEntity;
+    repository.findOne!.mockResolvedValueOnce(user);
+    rolesService.findOne = jest.fn().mockResolvedValue(newRole);
+    repository.save!.mockResolvedValue({ ...user, roles: [existingRole, newRole] });
+
+    const result = await service.assignRoles(1, { roleIds: [2] } as any);
+
+    expect(user.roles).toEqual([existingRole, newRole]);
+    expect(result.roles).toEqual([existingRole, newRole]);
+  });
+
+  it('removes a role from user', async () => {
+    const role = { id: 1 } as any;
+    const otherRole = { id: 2 } as any;
+    const user = { id: 1, roles: [role, otherRole] } as UserEntity;
+    repository.findOne!.mockResolvedValueOnce(user);
+    rolesService.findOne = jest.fn().mockResolvedValue(role);
+
+    const result = await service.removeRole(1, 1);
+
+    expect(rolesService.findOne).toHaveBeenCalledWith(1);
+    expect(user.roles).toEqual([otherRole]);
+    expect(repository.save).toHaveBeenCalledWith(user);
+    expect(result.message).toBe('Rol eliminado');
+  });
+
+  it('throws when user not found in private findById', async () => {
+    repository.findOne!.mockResolvedValueOnce(null);
+
+    await expect((service as any).findById(1)).rejects.toThrow('El usuario no existe');
   });
 });

--- a/test/utils/mock-repository.ts
+++ b/test/utils/mock-repository.ts
@@ -1,0 +1,19 @@
+import { Repository } from 'typeorm';
+
+export type MockRepository<T = any> = {
+  [P in keyof Repository<T>]: Repository<T>[P] extends (...args: any[]) => any
+    ? jest.MockedFunction<Repository<T>[P]>
+    : Repository<T>[P];
+};
+
+export const createMockRepository = <T = any>(): Partial<MockRepository<T>> => ({
+  create: jest.fn(),
+  save: jest.fn(),
+  find: jest.fn(),
+  findOne: jest.fn(),
+  findOneBy: jest.fn(),
+  remove: jest.fn(),
+  merge: jest.fn(),
+  delete: jest.fn(),
+  query: jest.fn(),
+});


### PR DESCRIPTION
## Summary
- add a shared repository mock helper for Jest-based service tests
- expand unit tests for all service modules to cover CRUD success paths, error handling, and dependency interactions

## Testing
- npm test -- --runInBand src/services/consultorio/consultorio.service.spec.ts src/services/empleado/empleado.service.spec.ts src/services/especialidad/especialidad.service.spec.ts src/services/estado-turno/estado-turno.service.spec.ts src/services/grupo-sanguineo/grupo-sanguineo.service.spec.ts src/services/historia-clinica/historia-clinica.service.spec.ts src/services/paciente/paciente.service.spec.ts src/services/permissions/permissions.service.spec.ts src/services/persona/persona.service.spec.ts src/services/procedimiento/procedimiento.service.spec.ts src/services/roles/roles.service.spec.ts src/services/tipo-empleado/tipo-empleado.service.spec.ts src/services/turno/turno.service.spec.ts src/services/users/users.service.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68d74de40a84832abbd754ad4ffa4263